### PR TITLE
Upgrade sphinx-palewire-theme to 0.1.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "sphinx-autobuild",
     "sphinx-copybutton",
     "myst-parser",
-    "sphinx-palewire-theme",
+    "sphinx-palewire-theme==0.1.3",
     # Tutorial dependencies
     "bln",
     "jupyterlab",

--- a/uv.lock
+++ b/uv.lock
@@ -437,7 +437,7 @@ requires-dist = [
     { name = "sphinx" },
     { name = "sphinx-autobuild" },
     { name = "sphinx-copybutton" },
-    { name = "sphinx-palewire-theme" },
+    { name = "sphinx-palewire-theme", specifier = "==0.1.3" },
     { name = "stamina" },
     { name = "tabulate" },
     { name = "tqdm" },
@@ -1283,7 +1283,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "ptyprocess" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [


### PR DESCRIPTION
Upgrade `sphinx-palewire-theme` to `0.1.3`.

Validation: Passed: `uv run --python 3.13 --with . -- sphinx-build -b html docs _build/html`. myst v5.0.0: MdParserConfig(commonmark_only=False, gfm_only=False, enable_extensions={'colon_fence', 'attrs_block'}, disable_syntax=[], all_links_external=False, links_external_new_tab=False, url_schemes=('http', 'https', 'mailto', 'ftp'), ref_domains=None, fence_as_directive=set(), number_code_blocks=[], title_to_header=False, heading_anchors=0, heading_slug_func=None, html_meta={}, footnote_sort=True, footnote_transition=True, words_per_minute=200, substitutions={}, linkify_fuzzy_links=True, dmath_allow_labels=True, dmath_allow_space=True, dmath_allow_digits=True, dmath_double_inline=False, update_mathjax=True, mathjax_classes='tex2jax_process|mathjax_process|math|output_area', enable_chec

No unrelated changes included.